### PR TITLE
[fix]:unterminated string error handling

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -12,9 +12,6 @@
 #include <iostream>
 #include <sstream>
 
-// TODO: If a string is unterminated inside the expanded nodes, it shows up as
-// unknown token errors. fix it. it should throw unterminated string error
-
 void run_file(std::ifstream &file) {
     std::stringstream ss;
     ss << file.rdbuf();

--- a/src/Tokenizer.cpp
+++ b/src/Tokenizer.cpp
@@ -130,8 +130,8 @@ void Tokenizer::handleIdentifier() {
 Result<void> Tokenizer::handleString() {
     while (peek() != '"' && !isAtEnd()) {
         if (peek() == '\n') {
-            line++;
-            column = 1;
+            return Result<void>::err("Tokenizer", "Unterminated string literal",
+                                     line, column);
         }
 
         if (peek() == '\\') {


### PR DESCRIPTION
Since the DSL doesn't need multi-line strings, i made \n an error condition instead of allowing it which fixed the error that was caused by unterminated strings that went on for lines!
fixes #1 